### PR TITLE
Fix parsing $abc:[Int]!, $abc:[Int!]!

### DIFF
--- a/src/commonMain/kotlin/com/kgbier/graphql/parser/GraphQl.kt
+++ b/src/commonMain/kotlin/com/kgbier/graphql/parser/GraphQl.kt
@@ -560,8 +560,8 @@ internal class GraphQl {
         ))
 
         typeDeferred = oneOf(listOf(
-                listType,
                 nonNullType,
+                listType,
                 namedType
         ))
 

--- a/src/commonTest/kotlin/com/kgbier/graphql/parser/GraphQlTest.kt
+++ b/src/commonTest/kotlin/com/kgbier/graphql/parser/GraphQlTest.kt
@@ -232,6 +232,7 @@ internal class GraphQlTest {
 
         assertEquals("[Int]!!", testSubject("[Int]!"))
         assertEquals("Int!!", testSubject("Int!"))
+        assertEquals("[Int!!]!!", testSubject("[Int!]!"))
     }
 
     @Test
@@ -257,6 +258,10 @@ internal class GraphQlTest {
         assertEquals(VariableDefinition("abc", "Int", null), testSubject("\$abc : Int"))
         assertEquals(VariableDefinition("abc", "Int", Value.ValueInt("123")), testSubject("\$abc : Int = 123"))
         assertEquals(VariableDefinition("abc", "Int", Value.ValueInt("123")), testSubject("\$abc:Int=123"))
+        assertEquals(VariableDefinition("abc", "[Int]", null), testSubject("\$abc:[Int]"))
+        assertEquals(VariableDefinition("abc", "[Int!!]", null), testSubject("\$abc:[Int!]"))
+        assertEquals(VariableDefinition("abc", "[Int]!!", null), testSubject("\$abc:[Int]!"))
+        assertEquals(VariableDefinition("abc", "[Int!!]!!", null), testSubject("\$abc:[Int!]!"))
     }
 
     @Test


### PR DESCRIPTION
For this to work the nonNullType must be the first one in typeDeferred,
otherwise parsing would stop at nonNullType and wouldn't parse the "!", but would
stop parsing altogether.

@kgbier Is there a reason for storing double "!!" for non nullable types in the syntax tree? Why not just "!" as in the input?

https://github.com/kgbier/graphql-parser-kotlin/blob/18a7cfec1e746b95b1b58b3578ca031d2698d9d1/src/commonMain/kotlin/com/kgbier/graphql/parser/GraphQl.kt#L313-L314